### PR TITLE
Account for a feature that may not have geometry

### DIFF
--- a/src/OverlappingFeatureSpiderfier.ts
+++ b/src/OverlappingFeatureSpiderfier.ts
@@ -342,7 +342,8 @@ class OverlappingFeatureSpiderfier {
     }
 
     private addFeature(feature: IExtendedFeature) {
-        if (feature.getGeometry().getType() !== "Point") return;
+        var geo = feature.getGeometry();
+        if (!geo || geo.getType() !== "Point") return;
         if (feature._oms) return;
 
         feature._oms = true;


### PR DESCRIPTION
This change adds an extra check before trying to create a marker for every feature with a Point geometry, to also check that is has ANY geometry first.

